### PR TITLE
chore: specify version of hosting action, contrary to docs

### DIFF
--- a/.github/workflows/apphosting.yml
+++ b/.github/workflows/apphosting.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Firebase App Hosting
-        uses: FirebaseExtended/github-action-hosting@v0
+        uses: FirebaseExtended/github-action-hosting@v0.9.0
         with:
           repoToken: "${{ secrets.GITHUB_TOKEN }}"
           firebaseServiceAccount: "${{ secrets.FIREBASE_SERVICE_ACCOUNT }}"


### PR DESCRIPTION
Docs were incorrect (though perhaps I should have been suspicious with v0). 

Having checked the version on their GitHub, it appears the latest version is 0.9, so here goes!