### PR TITLE
chore: tidy up unused env values

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ I achieved secrets this way:
 - Then, I had to grant access for **each** one, like this:
 
 ```bash
-firebase apphosting:secrets:grantaccess -b talent-deck KANTATA_CLIENT_ID
+firebase apphosting:secrets:grantaccess -b talent-deck NEXT_PUBLIC_KANTATA_CLIENT_ID
 ```
 
 It then deployed.

--- a/app/api/kantata/callback/route.ts
+++ b/app/api/kantata/callback/route.ts
@@ -19,7 +19,7 @@ export async function GET(req: NextRequest) {
     body: new URLSearchParams({
       grant_type: "authorization_code",
       code,
-      client_id: process.env.KANTATA_CLIENT_ID,
+      client_id: process.env.NEXT_PUBLIC_KANTATA_CLIENT_ID,
       client_secret: process.env.KANTATA_CLIENT_SECRET,
       redirect_uri: process.env.NEXT_PUBLIC_KANTATA_CALLBACK_URL,
     }),

--- a/apphosting.yaml
+++ b/apphosting.yaml
@@ -14,10 +14,6 @@ env:
     secret: projects/421795921996/secrets/NEXT_PUBLIC_KANTATA_CLIENT_ID
   - variable: KANTATA_TOKEN_URL
     secret: projects/421795921996/secrets/KANTATA_TOKEN_URL
-  - variable: KANTATA_CALLBACK_URL
-    secret: projects/421795921996/secrets/KANTATA_CALLBACK_URL
-  - variable: KANTATA_CLIENT_ID
-    secret: projects/421795921996/secrets/KANTATA_CLIENT_ID
   - variable: KANTATA_CLIENT_SECRET
     secret: projects/421795921996/secrets/KANTATA_CLIENT_SECRET
   - variable: GOOGLE_CLIENT_ID

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -4,8 +4,6 @@ namespace NodeJS {
     NEXT_PUBLIC_KANTATA_CLIENT_ID: string;
 
     KANTATA_TOKEN_URL: string;
-    KANTATA_CALLBACK_URL: string;
-    KANTATA_CLIENT_ID: string;
     KANTATA_CLIENT_SECRET: string;
 
     GOOGLE_CLIENT_ID: string;


### PR DESCRIPTION
Removed some duplication between `PUBLIC` and non-`PUBLIC` env variables.