### PR TITLE
feat: include instructions for partially generated slides

### DIFF
--- a/app/actions/generateSlides.ts
+++ b/app/actions/generateSlides.ts
@@ -84,7 +84,7 @@ export async function processDataAndGenerateSlides({
   let slideInfo: GenerateSlidesResult;
   try {
     slideInfo = await generateSlides({
-      clientName: projectDetails.clientName,
+      capturedInfo: projectDetails,
       resources: slidesData,
       accessToken: session?.accessToken,
     });

--- a/components/chatHistory.tsx
+++ b/components/chatHistory.tsx
@@ -37,18 +37,18 @@ export const ChatHistory = ({
                   <div className="max-w-xl">{msg.component}</div>
                 ) : (
                   // Render text if it's not a component
-                  <div className="max-w-xl text-lg text-gray-200 whitespace-pre-line">
+                  <div className="max-w-xl text-md text-gray-200 whitespace-pre-line">
                     <Typewriter
                       words={[msg.text || ""]}
                       loop={1}
-                      typeSpeed={30}
+                      typeSpeed={15}
                       deleteSpeed={0}
                       delaySpeed={1000}
                     />
                   </div>
                 )
               ) : (
-                <div className="px-4 py-3 rounded-xl bg-[#2e8fff] text-white max-w-xl text-lg whitespace-pre-line">
+                <div className="px-3 py-1 rounded-xl bg-[#FFE7D0] text-gray-800 max-w-xl text-md whitespace-pre-line">
                   {msg.text}
                 </div>
               )}

--- a/components/slidesPreview.tsx
+++ b/components/slidesPreview.tsx
@@ -21,8 +21,17 @@ export function SlidesPreview({
   );
   const hasFetched = useRef(false); // Prevent double-fetch in dev
 
+  const allCaptured = Object.values(projectDetails).every(
+    (value) => value.trim() !== "",
+  );
+
+  console.log({
+    allCaptured,
+    projectDetails,
+  });
+
   useEffect(() => {
-    if (hasFetched.current) return;
+    if (!allCaptured || hasFetched.current) return;
     hasFetched.current = true;
 
     const fetchSlides = async () => {
@@ -51,9 +60,9 @@ export function SlidesPreview({
     };
 
     fetchSlides();
-  }, [projectDetails, onComplete]);
+  }, [projectDetails, onComplete, allCaptured]);
 
-  if (loading || !slidesResult) {
+  if (!allCaptured || loading || !slidesResult) {
     return null;
   }
 

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,5 +1,6 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import { CapturedInfo, GeneratedEngineerResource } from "./api/models/types";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -17,9 +18,42 @@ export function getInitials(name: string): string {
     .join("");
 }
 
+export function getFirstName(name: string): string {
+  return name.trim().split(/\s+/)[0] ?? "";
+}
+
 export function getErrorStack(err: Error | unknown): string | undefined {
   if (process.env.NODE_ENV === "development" && err instanceof Error) {
     return err.stack;
   }
   return undefined;
+}
+
+export function isCapturedInfoComplete(info: CapturedInfo): boolean {
+  return Object.values(info).every((value) => value.trim());
+}
+
+export function generateMissingSummary(
+  engineer: GeneratedEngineerResource,
+): string | null {
+  const missing: string[] = [];
+
+  if (engineer.certifications.length === 0) {
+    missing.push("certifications");
+  }
+
+  const hasIncompleteProjects =
+    engineer.projects.length === 0 ||
+    engineer.projects.some((p) => !p.client.trim() || !p.description.trim());
+
+  if (hasIncompleteProjects) {
+    missing.push("project details");
+  }
+
+  if (missing.length === 0) return null;
+
+  const list =
+    missing.length === 1 ? missing[0] : `${missing[0]} and ${missing[1]}`;
+
+  return list;
 }


### PR DESCRIPTION
- added 'prompt' to any slides with incomplete information (most likely to be certifications or project details)
- refactored `SlidesPreview` rendering with a `useEffect` and only render if all the required information is available (it wasn't quite right before - the `otherDetails` wasn't being set correctly

![image](https://github.com/user-attachments/assets/ed255c8c-2ce2-4b92-bb4f-0eafa82f9ba2)
