### PR TITLE
feat: restrict logins to qodea domain

### DIFF
--- a/lib/auth/options.ts
+++ b/lib/auth/options.ts
@@ -12,6 +12,7 @@ export const authOptions: AuthOptions = {
           prompt: "consent",
           access_type: "offline",
           response_type: "code",
+          hd: process.env.ALLOWED_LOGIN_DOMAIN,
           scope:
             "openid email profile https://www.googleapis.com/auth/presentations https://www.googleapis.com/auth/drive",
         },
@@ -19,8 +20,11 @@ export const authOptions: AuthOptions = {
     }),
   ],
   callbacks: {
-    async signIn() {
-      return true;
+    async signIn({ profile }) {
+      const allowedDomain = process.env.ALLOWED_LOGIN_DOMAIN;
+      const emailDomain = profile?.email?.split("@")[1];
+
+      return emailDomain === allowedDomain;
     },
     async jwt({
       token,

--- a/process-env.d.ts
+++ b/process-env.d.ts
@@ -11,5 +11,9 @@ namespace NodeJS {
     NEXTAUTH_SECRET: string;
 
     KANTATA_API_BASE_URL: string;
+
+    GEMINI_API_KEY: string;
+
+    ALLOWED_LOGIN_DOMAIN: string;
   }
 }


### PR DESCRIPTION
- added a new env value `ALLOWED_LOGIN_DOMAIN` (and oops - needed to add a previously missed `GEMINI_API_KEY` key in the environment type definitions);
- added restriction at login screen level ;(this is more as a convenience than a security improvement);

![image](https://github.com/user-attachments/assets/e20c7a32-c812-40db-a916-492434b5a162)

- added restriction at login level that will reject logins not associated with the qodea domain